### PR TITLE
Fix Sequelize pool configuration bug

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -5,7 +5,10 @@ var Sequelize = require('sequelize');
 
 let databaseOptions = {
   logging: process.env.NODE_ENV === 'development' ? console.log : false,
-  pool: { maxConnections: 10, minConnections: 1 }
+  // Sequelize expects `pool` options to be named `max` and `min`.
+  // Using `maxConnections` and `minConnections` leaves the pool
+  // configuration ineffective and can exhaust database connections.
+  pool: { max: 10, min: 1 }
 };
 
 if (process.env.SSL_DATABASE) {


### PR DESCRIPTION
## Summary
- configure Sequelize pool options using `max`/`min`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68400845c15c83259e24e6b1265f205e